### PR TITLE
Implement base .lrc parser

### DIFF
--- a/LrcParser.Tests/Parser/BaseLyricParserTest.cs
+++ b/LrcParser.Tests/Parser/BaseLyricParserTest.cs
@@ -1,0 +1,14 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using LrcParser.Model;
+using LrcParser.Parser;
+
+namespace LrcParser.Tests.Parser;
+
+public class BaseLyricParserTest<TParser> where TParser : LyricParser, new()
+{
+    protected Song Decode(string text) => new TParser().Decode(text);
+
+    protected string Encode(Song component) => new TParser().Encode(component);
+}

--- a/LrcParser.Tests/Parser/Lines/BaseSingleLineParserTest.cs
+++ b/LrcParser.Tests/Parser/Lines/BaseSingleLineParserTest.cs
@@ -7,6 +7,8 @@ namespace LrcParser.Tests.Parser.Lines;
 
 public class BaseSingleLineParserTest<TParser, TModel> where TParser : SingleLineParser<TModel>, new() where TModel : class
 {
+    protected bool CanDecode(string text) => new TParser().CanDecode(text);
+
     protected TModel Decode(string text) => new TParser().Decode(text);
 
     protected string Encode(TModel component) => new TParser().Encode(component);

--- a/LrcParser.Tests/Parser/Lines/BaseSingleLineParserTest.cs
+++ b/LrcParser.Tests/Parser/Lines/BaseSingleLineParserTest.cs
@@ -5,7 +5,7 @@ using LrcParser.Parser.Lines;
 
 namespace LrcParser.Tests.Parser.Lines;
 
-public class BaseSingleLineParserTest<TParser, TModel> where TParser : SingleLineParser<TModel>, new()
+public class BaseSingleLineParserTest<TParser, TModel> where TParser : SingleLineParser<TModel>, new() where TModel : class
 {
     protected TModel Decode(string text) => new TParser().Decode(text);
 

--- a/LrcParser.Tests/Parser/Lrc/Lines/LrcLyricParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Lines/LrcLyricParserTest.cs
@@ -11,6 +11,17 @@ namespace LrcParser.Tests.Parser.Lrc.Lines;
 
 public class LrcLyricParserTest : BaseSingleLineParserTest<LrcLyricParser, LrcLyric>
 {
+    [TestCase("[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22]", true)]
+    [TestCase("karaoke", true)]
+    [TestCase("", false)]
+    [TestCase(null, false)]
+    [TestCase("@Ruby1=帰,かえ", true)] // will take off this if no other parser to process this line.
+    public void TestCanDecode(string text, bool expected)
+    {
+        var actual = CanDecode(text);
+        Assert.AreEqual(expected, actual);
+    }
+
     [TestCase("[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22]", "帰り道は", new[]{ "[0,start]:17970", "[1,start]:18370", "[2,start]:18550", "[3,start]:18940", "[3,end]:19220" })]
     [TestCase("帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22]", "帰り道は", new[]{ "[1,start]:18370", "[2,start]:18550", "[3,start]:18940", "[3,end]:19220" })]
     [TestCase("[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は", "帰り道は", new[]{ "[0,start]:17970", "[1,start]:18370", "[2,start]:18550", "[3,start]:18940" })]

--- a/LrcParser.Tests/Parser/Lrc/Lines/LrcRubyParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Lines/LrcRubyParserTest.cs
@@ -10,6 +10,17 @@ namespace LrcParser.Tests.Parser.Lrc.Lines;
 
 public class LrcRubyParserTest : BaseSingleLineParserTest<LrcRubyParser, LrcRuby>
 {
+    [TestCase("@Ruby1=帰,かえ", true)]
+    [TestCase("", false)]
+    [TestCase(null, false)]
+    [TestCase("[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22]", false)]
+    [TestCase("karaoke", false)]
+    public void TestCanDecode(string text, bool expected)
+    {
+        var actual = CanDecode(text);
+        Assert.AreEqual(expected, actual);
+    }
+
     [TestCase("@Ruby1=帰,かえ,[00:53:19],[01:24:77]", "帰", "かえ", 53190, 84770)]
     [TestCase("@Ruby1=帰,かえ,[01:24:77]", "帰", "かえ", 84770, null)]
     [TestCase("@Ruby1=帰,かえ,,[01:24:77]", "帰", "かえ", null, 84770)]

--- a/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
@@ -1,0 +1,97 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using LrcParser.Model;
+using NUnit.Framework;
+
+namespace LrcParser.Tests.Parser.Lrc;
+
+public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
+{
+    [Test]
+    public void TestDecode()
+    {
+        const string lrc_text = "[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22]";
+
+        var expected = new Song
+        {
+            Lyrics = new List<Lyric>
+            {
+                new()
+                {
+                    Text = "帰り道は",
+                    TimeTags = new SortedDictionary<TextIndex, int?>
+                    {
+                        { new TextIndex(0), 17970 },
+                        { new TextIndex(1), 18370 },
+                        { new TextIndex(2), 18550 },
+                        { new TextIndex(3), 18940 },
+                        { new TextIndex(3, IndexState.End), 19220 },
+                    }
+                }
+            }
+        };
+        var actual = Decode(lrc_text);
+        areEqual(expected, actual);
+    }
+
+    [Ignore("Waiting for implementation")]
+    [Test]
+    public void TestDecodeWithRuby()
+    {
+
+    }
+
+    [Test]
+    public void TestEncode()
+    {
+        const string expected = "[00:17.97]帰[00:18.37]り[00:18.55]道[00:18.94]は[00:19.22]";
+
+        var song = new Song
+        {
+            Lyrics = new List<Lyric>
+            {
+                new()
+                {
+                    Text = "帰り道は",
+                    TimeTags = new SortedDictionary<TextIndex, int?>
+                    {
+                        { new TextIndex(0), 17970 },
+                        { new TextIndex(1), 18370 },
+                        { new TextIndex(2), 18550 },
+                        { new TextIndex(3), 18940 },
+                        { new TextIndex(3, IndexState.End), 19220 },
+                    }
+                }
+            }
+        };
+        var actual = Encode(song);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Ignore("Waiting for implementation")]
+    [Test]
+    public void TestEncodeWithRuby()
+    {
+
+    }
+
+    private void areEqual(Song expected, Song actual)
+    {
+        var expectedLyrics = expected.Lyrics;
+        var actualLyrics = actual.Lyrics;
+        var index = Math.Max(expectedLyrics.Count, actualLyrics.Count);
+        for (int i = 0; i < index; i++)
+        {
+            areEqual(expectedLyrics[i], actualLyrics[i]);
+        }
+    }
+
+    private void areEqual(Lyric expected, Lyric actual)
+    {
+        Assert.AreEqual(expected.Text, actual.Text);
+        Assert.AreEqual(expected.TimeTags, actual.TimeTags);
+    }
+}

--- a/LrcParser/Parser/Lines/ISingleLineParser.cs
+++ b/LrcParser/Parser/Lines/ISingleLineParser.cs
@@ -1,0 +1,11 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace LrcParser.Parser.Lines;
+
+public interface ISingleLineParser
+{
+    object Decode(string text);
+
+    string Encode(object component);
+}

--- a/LrcParser/Parser/Lines/ISingleLineParser.cs
+++ b/LrcParser/Parser/Lines/ISingleLineParser.cs
@@ -5,6 +5,10 @@ namespace LrcParser.Parser.Lines;
 
 public interface ISingleLineParser
 {
+    bool CanDecode(string text);
+
+    bool CanEncode(object component);
+
     object Decode(string text);
 
     string Encode(object component);

--- a/LrcParser/Parser/Lines/SingleLineParser.cs
+++ b/LrcParser/Parser/Lines/SingleLineParser.cs
@@ -9,6 +9,15 @@ namespace LrcParser.Parser.Lines;
 /// <typeparam name="T">Encode and decode object type</typeparam>
 public abstract class SingleLineParser<T> : ISingleLineParser where T: class
 {
+    public abstract bool CanDecode(string text);
+
+    public bool CanEncode(object component)
+        => component is T;
+
+    object ISingleLineParser.Decode(string text) => Decode(text);
+
+    public string Encode(object component) => Encode(component as T);
+
     /// <summary>
     /// Decode to target class and leave remain text
     /// </summary>
@@ -22,8 +31,4 @@ public abstract class SingleLineParser<T> : ISingleLineParser where T: class
     /// <param name="component"></param>
     /// <returns></returns>
     public abstract string Encode(T component);
-
-    object ISingleLineParser.Decode(string text) => Decode(text);
-
-    public string Encode(object component) => Encode(component as T);
 }

--- a/LrcParser/Parser/Lines/SingleLineParser.cs
+++ b/LrcParser/Parser/Lines/SingleLineParser.cs
@@ -7,7 +7,7 @@ namespace LrcParser.Parser.Lines;
 /// Base component pass string
 /// </inheritdoc>
 /// <typeparam name="T">Encode and decode object type</typeparam>
-public abstract class SingleLineParser<T>
+public abstract class SingleLineParser<T> : ISingleLineParser where T: class
 {
     /// <summary>
     /// Decode to target class and leave remain text
@@ -22,4 +22,8 @@ public abstract class SingleLineParser<T>
     /// <param name="component"></param>
     /// <returns></returns>
     public abstract string Encode(T component);
+
+    object ISingleLineParser.Decode(string text) => Decode(text);
+
+    public string Encode(object component) => Encode(component as T);
 }

--- a/LrcParser/Parser/Lrc/Lines/LrcLyricParser.cs
+++ b/LrcParser/Parser/Lrc/Lines/LrcLyricParser.cs
@@ -12,6 +12,9 @@ namespace LrcParser.Parser.Lrc.Lines;
 
 public class LrcLyricParser : SingleLineParser<LrcLyric>
 {
+    public override bool CanDecode(string text)
+        => !string.IsNullOrEmpty(text);
+
     public override LrcLyric Decode(string text)
     {
         if (string.IsNullOrEmpty(text))

--- a/LrcParser/Parser/Lrc/Lines/LrcRubyParser.cs
+++ b/LrcParser/Parser/Lrc/Lines/LrcRubyParser.cs
@@ -11,6 +11,9 @@ namespace LrcParser.Parser.Lrc.Lines;
 
 public class LrcRubyParser : SingleLineParser<LrcRuby>
 {
+    public override bool CanDecode(string text)
+        => !string.IsNullOrEmpty(text) && text.ToLower().StartsWith("@ruby");
+
     public override LrcRuby Decode(string text)
     {
         var rubyTextRegex = new Regex("@(Ruby|ruby)(?<index>[0-9]+)=(?<text>.*$)");

--- a/LrcParser/Parser/Lrc/LrcParser.cs
+++ b/LrcParser/Parser/Lrc/LrcParser.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using LrcParser.Model;
+using LrcParser.Parser.Lrc.Lines;
+using LrcParser.Parser.Lrc.Metadata;
 
 namespace LrcParser.Parser.Lrc;
 
@@ -10,13 +12,45 @@ namespace LrcParser.Parser.Lrc;
 /// </summary>
 public class LrcParser : LyricParser
 {
-    public override Lyric Decode(string text)
+    public LrcParser()
     {
-        throw new NotImplementedException();
+        Register<LrcRubyParser>();
+        Register<LrcLyricParser>();
     }
 
-    public override string Encode(Lyric lyric)
+    protected override Song PostProcess(List<object> values)
     {
-        throw new NotImplementedException();
+        var lyrics = values.OfType<LrcLyric>();
+        var rubies = values.OfType<LrcRuby>();
+
+        return new Song
+        {
+            Lyrics = lyrics.Select(l => new Lyric
+            {
+                Text = l.Text,
+                TimeTags = l.TimeTags
+                // todo: implement the ruby parsing.
+            }).ToList()
+        };
+    }
+
+    protected override IEnumerable<object> PreProcess(Song song)
+    {
+        var lyrics = song.Lyrics;
+
+        // first, should return the time-tag first.
+        foreach (var lyric in lyrics)
+        {
+            yield return new LrcLyric
+            {
+                Text = lyric.Text,
+                TimeTags = lyric.TimeTags,
+            };
+        }
+
+        // give it a line if contains ruby.
+        // yield return new object();
+
+        // then, export the ruby.
     }
 }

--- a/LrcParser/Parser/LyricParser.cs
+++ b/LrcParser/Parser/LyricParser.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using LrcParser.Model;
+using LrcParser.Parser.Lines;
 
 namespace LrcParser.Parser;
 
@@ -10,17 +11,56 @@ namespace LrcParser.Parser;
 /// </summary>
 public abstract class LyricParser
 {
+    private readonly IList<ISingleLineParser> parsers = new List<ISingleLineParser>();
+
+    protected void Register<TParser>() where TParser : ISingleLineParser, new()
+    {
+        parsers.Add(new TParser());
+    }
+
     /// <summary>
     /// Decode the lyric from the text.
     /// </summary>
     /// <param name="text"></param>
     /// <returns></returns>
-    public abstract Lyric Decode(string text);
+    public Song Decode(string text)
+    {
+        var lines = text.Split('\n');
+
+        // Generate all the objects.
+        var objects = lines.Select(x =>
+        {
+            var parser = parsers.FirstOrDefault(p => p.CanDecode(x));
+
+            return parser?.Decode(x);
+        }).Where(x => x != null).Select(x => x!).ToList();
+
+        // than pass to the post process.
+        return PostProcess(objects);
+    }
+
+    protected abstract Song PostProcess(List<object> values);
 
     /// <summary>
     /// Encode the lyric to the text format.
     /// </summary>
-    /// <param name="lyric"></param>
+    /// <param name="song"></param>
     /// <returns></returns>
-    public abstract string Encode(Lyric lyric);
+    public string Encode(Song song)
+    {
+        // read all property.
+        var objects = PreProcess(song);
+
+        // convert to lines.
+        var lines = objects.Select(x =>
+        {
+            var parser = parsers.FirstOrDefault(p => p.CanEncode(x));
+
+            return parser?.Encode(x) ?? "";
+        }).ToList();
+
+        return string.Join('\n', lines);
+    }
+
+    protected abstract IEnumerable<object> PreProcess(Song song);
 }


### PR DESCRIPTION
What's done in this PR:
- able to check is single line of file can be parse.
- implement the base structure of the main parser, and add the test case to test lyric with lyric only.