### PR TITLE
Fix parsing ruby with invalid position issue.

### DIFF
--- a/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
@@ -40,6 +40,55 @@ public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
     [Test]
     public void TestDecodeWithRuby()
     {
+        const string lrc_text = "[00:01:00]島[00:02:00]島[00:03:00]島[00:04:00]\n"
+            + "@Ruby1=島,しま,,[00:02:00]\n@Ruby2=島,じま,[00:02:00],[00:03:00]\n@Ruby3=島,とう,[00:03:00]";
+
+        var expected = new Song
+        {
+            Lyrics = new List<Lyric>
+            {
+                new()
+                {
+                    Text = "島島島",
+                    TimeTags = new SortedDictionary<TextIndex, int?>
+                    {
+                        { new TextIndex(0), 1000 },
+                        { new TextIndex(1), 2000 },
+                        { new TextIndex(2), 3000 },
+                        { new TextIndex(2, IndexState.End), 4000 },
+                    },
+                    RubyTags = new List<RubyTag>
+                    {
+                        new()
+                        {
+                            Text = "しま",
+                            StartIndex = 0,
+                            EndIndex = 1
+                        },
+                        new()
+                        {
+                            Text = "じま",
+                            StartIndex = 1,
+                            EndIndex = 2
+                        },
+                        new()
+                        {
+                            Text = "とう",
+                            StartIndex = 2,
+                            EndIndex = 3
+                        }
+                    }
+                },
+            }
+        };
+
+        var actual = Decode(lrc_text);
+        areEqual(expected, actual);
+    }
+
+    [Test]
+    public void TestDecodeWithRubyInDifferentLine()
+    {
         const string lrc_text = "[00:01:00]島[00:02:00]\n[00:03:00]島[00:04:00]\n[00:05:00]島[00:06:00]\n"
             + "@Ruby1=島,しま,,[00:02:00]\n@Ruby2=島,じま,[00:03:00],[00:04:00]\n@Ruby3=島,とう,[00:05:00]";
 
@@ -175,6 +224,55 @@ public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
 
     [Test]
     public void TestEncodeWithRuby()
+    {
+        const string expected = "[00:01.00]島[00:02.00]島[00:03.00]島[00:04.00]\n\n"
+                                + "@Ruby1=島,しま,,[00:02.00]\n@Ruby2=島,じま,[00:02.00],[00:03.00]\n@Ruby3=島,とう,[00:03.00]";
+
+        var song = new Song
+        {
+            Lyrics = new List<Lyric>
+            {
+                new()
+                {
+                    Text = "島島島",
+                    TimeTags = new SortedDictionary<TextIndex, int?>
+                    {
+                        { new TextIndex(0), 1000 },
+                        { new TextIndex(1), 2000 },
+                        { new TextIndex(2), 3000 },
+                        { new TextIndex(2, IndexState.End), 4000 },
+                    },
+                    RubyTags = new List<RubyTag>
+                    {
+                        new()
+                        {
+                            Text = "しま",
+                            StartIndex = 0,
+                            EndIndex = 1
+                        },
+                        new()
+                        {
+                            Text = "じま",
+                            StartIndex = 1,
+                            EndIndex = 2
+                        },
+                        new()
+                        {
+                            Text = "とう",
+                            StartIndex = 2,
+                            EndIndex = 3
+                        }
+                    }
+                },
+            }
+        };
+
+        var actual = Encode(song);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void TestEncodeWithRubyInDifferentLine()
     {
         const string expected = "[00:01.00]島[00:02.00]\n[00:03.00]島[00:04.00]\n[00:05.00]島[00:06.00]\n\n"
                                 + "@Ruby1=島,しま,,[00:02.00]\n@Ruby2=島,じま,[00:03.00],[00:04.00]\n@Ruby3=島,とう,[00:05.00]";

--- a/LrcParser/Parser/Lrc/LrcParser.cs
+++ b/LrcParser/Parser/Lrc/LrcParser.cs
@@ -53,7 +53,7 @@ public class LrcParser : LyricParser
                 {
                     var startTextIndex = match.Index;
                     var endTextIndex = startTextIndex + match.Length;
-                    var startTimeTag = timeTags.Reverse().LastOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) <= startTextIndex);
+                    var startTimeTag = timeTags.Reverse().LastOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= startTextIndex);
                     var endTimeTag = timeTags.FirstOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= endTextIndex);
 
                     if(rubyTag.StartTime.HasValue && rubyTag.StartTime > startTimeTag.Value)
@@ -130,7 +130,7 @@ public class LrcParser : LyricParser
                 var startIndex = rubyTag.StartIndex;
                 var endIndex = rubyTag.EndIndex;
 
-                var startTimeTag = timeTags.Reverse().LastOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) <= startIndex && x.Value.HasValue).Value;
+                var startTimeTag = timeTags.Reverse().LastOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= startIndex && x.Value.HasValue).Value;
                 var endTimeTag = timeTags.FirstOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= endIndex && x.Value.HasValue).Value;
 
                 yield return new LrcRuby


### PR DESCRIPTION
Fix will got the wrong ruby start and end index if the lrc format is like this:
```
[00:01:00]島[00:02:00]島[00:03:00]島[00:04:00]

@Ruby1=島,しま,,[00:02:00]
@Ruby2=島,じま,[00:02:00],[00:03:00]
@Ruby3=島,とう,[00:03:00]
```