### PR TITLE
Fix parsing ruby issue if contains no time range

### DIFF
--- a/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
@@ -319,6 +319,53 @@ public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
     }
 
     [Test]
+    public void TestEncodeWithNoTimeRangeRuby()
+    {
+        const string expected = "カラオケ\n\n@Ruby1=カ,か\n@Ruby2=ラ,ら\n@Ruby3=オ,お\n@Ruby4=ケ,け";
+
+        var song = new Song
+        {
+            Lyrics = new List<Lyric>
+            {
+                new()
+                {
+                    Text = "カラオケ",
+                    RubyTags = new List<RubyTag>
+                    {
+                        new()
+                        {
+                            Text = "か",
+                            StartIndex = 0,
+                            EndIndex = 1
+                        },
+                        new()
+                        {
+                            Text = "ら",
+                            StartIndex = 1,
+                            EndIndex = 2
+                        },
+                        new()
+                        {
+                            Text = "お",
+                            StartIndex = 2,
+                            EndIndex = 3
+                        },
+                        new()
+                        {
+                            Text = "け",
+                            StartIndex = 3,
+                            EndIndex = 4
+                        }
+                    }
+                },
+            }
+        };
+
+        var actual = Encode(song);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
     public void TestEncodeWithRubyInDifferentLine()
     {
         const string expected = "[00:01.00]島[00:02.00]\n[00:03.00]島[00:04.00]\n[00:05.00]島[00:06.00]\n\n"

--- a/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
@@ -87,6 +87,53 @@ public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
     }
 
     [Test]
+    public void TestDecodeWithNoTimeRangeRuby()
+    {
+        const string lrc_text = "カラオケ\n@Ruby1=カ,か\n@Ruby2=ラ,ら\n@Ruby3=オ,お\n@Ruby4=ケ,け";
+
+        var expected = new Song
+        {
+            Lyrics = new List<Lyric>
+            {
+                new()
+                {
+                    Text = "カラオケ",
+                    RubyTags = new List<RubyTag>
+                    {
+                        new()
+                        {
+                            Text = "か",
+                            StartIndex = 0,
+                            EndIndex = 1
+                        },
+                        new()
+                        {
+                            Text = "ら",
+                            StartIndex = 1,
+                            EndIndex = 2
+                        },
+                        new()
+                        {
+                            Text = "お",
+                            StartIndex = 2,
+                            EndIndex = 3
+                        },
+                        new()
+                        {
+                            Text = "け",
+                            StartIndex = 3,
+                            EndIndex = 4
+                        }
+                    }
+                },
+            }
+        };
+
+        var actual = Decode(lrc_text);
+        areEqual(expected, actual);
+    }
+
+    [Test]
     public void TestDecodeWithRubyInDifferentLine()
     {
         const string lrc_text = "[00:01:00]島[00:02:00]\n[00:03:00]島[00:04:00]\n[00:05:00]島[00:06:00]\n"

--- a/LrcParser/Parser/Lrc/LrcParser.cs
+++ b/LrcParser/Parser/Lrc/LrcParser.cs
@@ -23,7 +23,7 @@ public class LrcParser : LyricParser
     protected override Song PostProcess(List<object> values)
     {
         var lyrics = values.OfType<LrcLyric>();
-        var rubies = values.OfType<LrcRuby>().Where(x => x.Ruby != x.Parent);
+        var rubies = values.OfType<LrcRuby>();
 
         return new Song
         {
@@ -46,6 +46,9 @@ public class LrcParser : LyricParser
             {
                 if (string.IsNullOrEmpty(rubyTag.Ruby) || string.IsNullOrEmpty(rubyTag.Parent))
                     continue;
+
+                if(rubyTag.Ruby == rubyTag.Parent)
+                   continue;
 
                 var matches = new Regex(rubyTag.Parent).Matches(text);
 

--- a/LrcParser/Parser/Lrc/LrcParser.cs
+++ b/LrcParser/Parser/Lrc/LrcParser.cs
@@ -50,27 +50,44 @@ public class LrcParser : LyricParser
                 if(rubyTag.Ruby == rubyTag.Parent)
                    continue;
 
+                var hasStartTime = rubyTag.StartTime.HasValue;
+                var hasEndTime = rubyTag.EndTime.HasValue;
+
                 var matches = new Regex(rubyTag.Parent).Matches(text);
 
                 foreach (var match in matches.ToArray())
                 {
                     var startTextIndex = match.Index;
                     var endTextIndex = startTextIndex + match.Length;
-                    var startTimeTag = timeTags.Reverse().LastOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= startTextIndex);
-                    var endTimeTag = timeTags.FirstOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= endTextIndex);
 
-                    if(rubyTag.StartTime.HasValue && rubyTag.StartTime > startTimeTag.Value)
-                        continue;
-
-                    if(rubyTag.EndTime.HasValue && rubyTag.EndTime < endTimeTag.Value)
-                        continue;
-
-                    yield return new RubyTag
+                    if (!hasStartTime && !hasEndTime)
                     {
-                        Text = rubyTag.Ruby,
-                        StartIndex = TextIndexUtils.ToStringIndex(startTimeTag.Key),
-                        EndIndex = TextIndexUtils.ToStringIndex(endTimeTag.Key)
-                    };
+                        yield return new RubyTag
+                        {
+                            Text = rubyTag.Ruby,
+                            StartIndex = startTextIndex,
+                            EndIndex = endTextIndex
+                        };
+                    }
+                    else
+                    {
+                        var startTimeTag = timeTags.Reverse().LastOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= startTextIndex);
+                        var endTimeTag = timeTags.FirstOrDefault(x => TextIndexUtils.ToStringIndex(x.Key) >= endTextIndex);
+
+                        // should not add the ruby if is not in the time-range.
+                        if(hasStartTime && rubyTag.StartTime > startTimeTag.Value)
+                            continue;
+
+                        if(hasEndTime && rubyTag.EndTime < endTimeTag.Value)
+                            continue;
+
+                        yield return new RubyTag
+                        {
+                            Text = rubyTag.Ruby,
+                            StartIndex = TextIndexUtils.ToStringIndex(startTimeTag.Key),
+                            EndIndex = TextIndexUtils.ToStringIndex(endTimeTag.Key)
+                        };
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix will got the wrong ruby start and end index if the lrc format is like this:
```
カラオケ

@Ruby1=カ,か
@Ruby2=ラ,ら
@Ruby3=オ,お
@Ruby4=ケ,け
```

Also, moving the filter the ruby-tag with same parent logic added in the #17