### PR TITLE
Parse fails when files have multiple timestamps for single line of text

### DIFF
--- a/LrcParser.Tests/Parser/Lrc/Utils/LrcTimedTextUtilsTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Utils/LrcTimedTextUtilsTest.cs
@@ -15,6 +15,7 @@ public class LrcTimedTextUtilsTest
     [TestCase("[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22] ", "帰り道は ", new[] { "[0,start]:17970", "[1,start]:18370", "[2,start]:18550", "[3,start]:18940", "[3,end]:19220" })]
     [TestCase("帰[00:18:37]り[00:18:55]道[00:18:94]は[00:19:22]", "帰り道は", new[] { "[1,start]:18370", "[2,start]:18550", "[3,start]:18940", "[3,end]:19220" })]
     [TestCase("[00:17:97]帰[00:18:37]り[00:18:55]道[00:18:94]は", "帰り道は", new[] { "[0,start]:17970", "[1,start]:18370", "[2,start]:18550", "[3,start]:18940" })]
+    [TestCase("[00:51.00][01:29.99][01:48.29][02:31.00][02:41.99]You gotta fight !", "You gotta fight !", new string[] { "[0,start]:51000" })] // decode with invalid format.
     [TestCase("帰り道は", "帰り道は", new string[] { })]
     [TestCase("", "", new string[] { })]
     [TestCase(null, "", new string[] { })]

--- a/LrcParser/Parser/Lrc/Utils/LrcTimedTextUtils.cs
+++ b/LrcParser/Parser/Lrc/Utils/LrcTimedTextUtils.cs
@@ -44,7 +44,9 @@ internal static class LrcTimedTextUtils
             var state = hasText && !isEmptyStringNext ? IndexState.Start : IndexState.End;
             var textIndex = text.Length - (state == IndexState.Start ? 0 : 1);
             var time = TimeTagUtils.TimeTagToMillionSecond(match.Value);
-            timeTags.Add(new TextIndex(textIndex, state), time);
+
+            // using try add because it might be possible with duplicated time-tag position in the lyric.
+            timeTags.TryAdd(new TextIndex(textIndex, state), time);
         }
 
         // should add remaining text at the right of the end time-tag.


### PR DESCRIPTION
Fix issue found in the #40.

Will only save the first time-tag in the modal if got the duplicated time-tag in the lyric.