### PR TITLE
"<mm:dd.ss>" in the lyric store the absolute time, not the relative time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2024.0728
+## 2024.0728.2
+* "<mm:dd.ss>" in the `.lrc` file is absolute time, not the relative time.
+
+## 2024.0728.1
 * Add `StartTime` property in the `Model.Lyric` class. This property is used to store the start time of the lyric.~~
 * `LrcParse` is re-written. Now it can follow the [LRC and Enhanced LRC format](https://en.wikipedia.org/wiki/LRC_(file_format) to decode/encode the lyric correctly.
 * Create the `KarParser`, which is~~~~ u~~~~sed to parse the Karaoke file with format like `[00:51.00]ka[01:29.99]ra[01:48.29]o[02:31.00]ke[02:41.99]`.

--- a/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/LrcParserTest.cs
@@ -14,7 +14,7 @@ public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
     {
         var lrcText = new[]
         {
-            "[00:17.00] <00:00.00>帰<00:01.00>り<00:02.00>道<00:03.00>は<00:04.00>",
+            "[00:17.00] <00:17.00>帰<00:18.00>り<00:19.00>道<00:20.00>は<00:21.00>",
         };
 
         var song = new Song
@@ -65,7 +65,7 @@ public class LrcParserTest : BaseLyricParserTest<LrcParser.Parser.Lrc.LrcParser>
 
         var lrcText = new[]
         {
-            "[00:17.00] <00:00.00>帰<00:01.00>り<00:02.00>道<00:03.00>は<00:04.00>",
+            "[00:17.00] <00:17.00>帰<00:18.00>り<00:19.00>道<00:20.00>は<00:21.00>",
         };
 
         checkEncode(song, lrcText);

--- a/LrcParser/Parser/Lrc/LrcParser.cs
+++ b/LrcParser/Parser/Lrc/LrcParser.cs
@@ -37,13 +37,13 @@ public class LrcParser : LyricParser, IHasParserConfig<LrcEncodeConfig, LrcDecod
                 {
                     Text = lrcLyric.Text,
                     StartTime = startTime,
-                    TimeTags = getTimeTags(lrcLyric.TimeTags, startTime),
+                    TimeTags = getTimeTags(lrcLyric.TimeTags),
                 };
             }
         }
 
-        static SortedDictionary<TextIndex, int?> getTimeTags(SortedDictionary<TextIndex, int> timeTags, int offsetTime)
-            => new(timeTags.ToDictionary(k => k.Key, v => v.Value + offsetTime as int?));
+        static SortedDictionary<TextIndex, int?> getTimeTags(SortedDictionary<TextIndex, int> timeTags)
+            => new(timeTags.ToDictionary(k => k.Key, v => v.Value as int?));
     }
 
     protected override IEnumerable<object> PreProcess(Song song)
@@ -58,7 +58,7 @@ public class LrcParser : LyricParser, IHasParserConfig<LrcEncodeConfig, LrcDecod
             {
                 Text = lyric.Text,
                 StartTimes = [lyric.StartTime],
-                TimeTags = getTimeTags(lyric.TimeTags, -lyric.StartTime),
+                TimeTags = getTimeTags(lyric.TimeTags),
             };
         }
 
@@ -72,7 +72,7 @@ public class LrcParser : LyricParser, IHasParserConfig<LrcEncodeConfig, LrcDecod
 
         yield break;
 
-        static SortedDictionary<TextIndex, int> getTimeTags(SortedDictionary<TextIndex, int?> timeTags, int offsetTime = 0)
-            => new(timeTags.Where(x => x.Value.HasValue).ToDictionary(k => k.Key, v => v.Value!.Value + offsetTime));
+        static SortedDictionary<TextIndex, int> getTimeTags(SortedDictionary<TextIndex, int?> timeTags)
+            => new(timeTags.Where(x => x.Value.HasValue).ToDictionary(k => k.Key, v => v.Value!.Value));
     }
 }

--- a/LrcParser/Parser/Lrc/Metadata/LrcLyric.cs
+++ b/LrcParser/Parser/Lrc/Metadata/LrcLyric.cs
@@ -24,7 +24,7 @@ public struct LrcLyric : IEquatable<LrcLyric>
 
     /// <summary>
     /// Time tags.
-    /// It's the relative time from the start time.
+    /// It's the absolute time.
     /// </summary>
     public SortedDictionary<TextIndex, int> TimeTags { get; set; } = new();
 


### PR DESCRIPTION
Found in the #40 (see: https://github.com/karaoke-dev/LrcParser/issues/40#issuecomment-2254519872)