### PR TITLE
Fix conversion of timestamps in 3 decimal places

### DIFF
--- a/LrcParser.Tests/Parser/Lrc/Utils/LrcStartTimeUtilsTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Utils/LrcStartTimeUtilsTest.cs
@@ -43,6 +43,7 @@ public class LrcStartTimeUtilsTest
     [TestCase("[01:00.00]", 60000)]
     [TestCase("[10:00.00]", 600000)]
     [TestCase("[100:00.00]", 6000000)]
+    [TestCase("[12:34.567]", 754560)]
     [TestCase("[0:00.00]", 0)] // prevent throw error in some invalid format.
     [TestCase("[0:0.0]", 0)] // prevent throw error in some invalid format.
     [TestCase("[1:00.00][1:02.00]", 60000)] // rarely to get this case, so return the first one.

--- a/LrcParser.Tests/Parser/Lrc/Utils/LrcTimedTextUtilsTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Utils/LrcTimedTextUtilsTest.cs
@@ -42,6 +42,7 @@ public class LrcTimedTextUtilsTest
     [TestCase("<01:00.00>", 60000)]
     [TestCase("<10:00.00>", 600000)]
     [TestCase("<100:00.00>", 6000000)]
+    [TestCase("<12:34.567>", 754560)]
     [TestCase("<0:00.00>", 0)] // prevent throw error in some invalid format.
     [TestCase("<0:0.0>", 0)] // prevent throw error in some invalid format.
     [TestCase("<1:00.00><1:02.00>", 60000)] // rarely to get this case, so return the first one.

--- a/LrcParser/Parser/Lrc/Utils/LrcStartTimeUtils.cs
+++ b/LrcParser/Parser/Lrc/Utils/LrcStartTimeUtils.cs
@@ -47,6 +47,7 @@ public class LrcStartTimeUtils
         int minutes = int.Parse(match.Groups[1].Value);
         int seconds = int.Parse(match.Groups[2].Value);
         int hundredths = int.Parse(match.Groups[3].Value);
+        hundredths = (hundredths < 100) ? hundredths : (hundredths / 10);
 
         return minutes * 60 * 1000 + seconds * 1000 + hundredths * 10;
     }

--- a/LrcParser/Parser/Lrc/Utils/LrcTimedTextUtils.cs
+++ b/LrcParser/Parser/Lrc/Utils/LrcTimedTextUtils.cs
@@ -77,6 +77,7 @@ internal static class LrcTimedTextUtils
         int minutes = int.Parse(match.Groups[1].Value);
         int seconds = int.Parse(match.Groups[2].Value);
         int hundredths = int.Parse(match.Groups[3].Value);
+        hundredths = (hundredths < 100) ? hundredths : (hundredths / 10);
 
         return minutes * 60 * 1000 + seconds * 1000 + hundredths * 10;
     }


### PR DESCRIPTION
Timestamps in 3 decimal places cannot be converted to milliseconds correctly.

Such as `[12:34.567]`
Expected: `754560`  -> ` [12:34:56]`
But was: `759670`  -> ` [12:39:67]`

This results in the wrong order of lyrics.