### PR TITLE
Update deploy-pack.yml

### DIFF
--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -58,7 +58,7 @@ jobs:
         run: dotnet pack -c Release LrcParser /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: osu-framework
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg


### PR DESCRIPTION
v2 is deprecated.
see:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/