### PR TITLE
Improve LRC time tag parsing and processing

### DIFF
--- a/LrcParser.Tests/Parser/Lrc/Utils/LrcStartTimeUtilsTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Utils/LrcStartTimeUtilsTest.cs
@@ -38,30 +38,6 @@ public class LrcStartTimeUtilsTest
         Assert.That(actual.Item2, Is.EqualTo(lyric));
     }
 
-    [TestCase("[00:00.00]", 0)]
-    [TestCase("[00:06.00]", 6000)]
-    [TestCase("[01:00.00]", 60000)]
-    [TestCase("[10:00.00]", 600000)]
-    [TestCase("[100:00.00]", 6000000)]
-    [TestCase("[12:34.567]", 754560)]
-    [TestCase("[0:00.00]", 0)] // prevent throw error in some invalid format.
-    [TestCase("[0:0.0]", 0)] // prevent throw error in some invalid format.
-    [TestCase("[1:00.00][1:02.00]", 60000)] // rarely to get this case, so return the first one.
-    public void TestConvertTimeTagToMillionSecond(string timeTag, int expectedMillionSecond)
-    {
-        var actual = LrcStartTimeUtils.ConvertTimeTagToMillionSecond(timeTag);
-
-        Assert.That(actual, Is.EqualTo(expectedMillionSecond));
-    }
-
-    [TestCase("[--:--.--]")]
-    [TestCase("[]")]
-    [TestCase("<1:00.00>")] // should not contains embedded time-tag.
-    public void TestConvertTimeTagToMillionSecondWithInvalidValue(string timeTag)
-    {
-        Assert.Throws<InvalidOperationException>(() => LrcStartTimeUtils.ConvertTimeTagToMillionSecond(timeTag));
-    }
-
     #endregion
 
     #region Encode
@@ -82,24 +58,6 @@ public class LrcStartTimeUtilsTest
     public void TestEncodeWithInvalidValue(int[] startTimes, string expectedLine)
     {
         Assert.Throws<InvalidOperationException>(() => LrcStartTimeUtils.JoinLyricAndTimeTag(startTimes, expectedLine));
-    }
-
-    [TestCase(0, "[00:00.00]")]
-    [TestCase(6000, "[00:06.00]")]
-    [TestCase(60000, "[01:00.00]")]
-    [TestCase(600000, "[10:00.00]")]
-    [TestCase(6000000, "[100:00.00]")]
-    public void TestConvertMillionSecondToTimeTag(int millionSecond, string expectedTimeTag)
-    {
-        var actual = LrcStartTimeUtils.ConvertMillionSecondToTimeTag(millionSecond);
-
-        Assert.That(actual, Is.EqualTo(expectedTimeTag));
-    }
-
-    [TestCase(-1)]
-    public void TestConvertMillionSecondToTimeTagWithInvalidValue(int millionSecond)
-    {
-        Assert.Throws<InvalidOperationException>(() => LrcStartTimeUtils.ConvertMillionSecondToTimeTag(millionSecond));
     }
 
     #endregion

--- a/LrcParser.Tests/Parser/Lrc/Utils/LrcTimedTextUtilsTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Utils/LrcTimedTextUtilsTest.cs
@@ -37,30 +37,6 @@ public class LrcTimedTextUtilsTest
         Assert.That(actualTimeTags, Is.EqualTo(TestCaseTagHelper.ParseTimeTags(expectedTimeTags)));
     }
 
-    [TestCase("<00:00.00>", 0)]
-    [TestCase("<00:06.00>", 6000)]
-    [TestCase("<01:00.00>", 60000)]
-    [TestCase("<10:00.00>", 600000)]
-    [TestCase("<100:00.00>", 6000000)]
-    [TestCase("<12:34.567>", 754560)]
-    [TestCase("<0:00.00>", 0)] // prevent throw error in some invalid format.
-    [TestCase("<0:0.0>", 0)] // prevent throw error in some invalid format.
-    [TestCase("<1:00.00><1:02.00>", 60000)] // rarely to get this case, so return the first one.
-    public void TestConvertTimeTagToMillionSecond(string timeTag, int expectedMillionSecond)
-    {
-        var actual = LrcTimedTextUtils.ConvertTimeTagToMillionSecond(timeTag);
-
-        Assert.That(actual, Is.EqualTo(expectedMillionSecond));
-    }
-
-    [TestCase("<--:--.-->")]
-    [TestCase("<>")]
-    [TestCase("[1:00.00]")] // should not contains start time-tag.
-    public void TestConvertTimeTagToMillionSecondWithInvalidValue(string timeTag)
-    {
-        Assert.Throws<InvalidOperationException>(() => LrcTimedTextUtils.ConvertTimeTagToMillionSecond(timeTag));
-    }
-
     #endregion
 
     #region Encode
@@ -77,24 +53,6 @@ public class LrcTimedTextUtilsTest
         var actual = LrcTimedTextUtils.ToTimedText(text, TestCaseTagHelper.ParseTimeTags(timeTags));
 
         Assert.That(actual, Is.EqualTo(expected));
-    }
-
-    [TestCase(0, "<00:00.00>")]
-    [TestCase(6000, "<00:06.00>")]
-    [TestCase(60000, "<01:00.00>")]
-    [TestCase(600000, "<10:00.00>")]
-    [TestCase(6000000, "<100:00.00>")]
-    public void TestConvertMillionSecondToTimeTag(int millionSecond, string expectedTimeTag)
-    {
-        var actual = LrcTimedTextUtils.ConvertMillionSecondToTimeTag(millionSecond);
-
-        Assert.That(actual, Is.EqualTo(expectedTimeTag));
-    }
-
-    [TestCase(-1)]
-    public void TestConvertMillionSecondToTimeTagWithInvalidValue(int millionSecond)
-    {
-        Assert.Throws<InvalidOperationException>(() => LrcTimedTextUtils.ConvertMillionSecondToTimeTag(millionSecond));
     }
 
     #endregion

--- a/LrcParser.Tests/Parser/Lrc/Utils/TimeTagUtilsTest.cs
+++ b/LrcParser.Tests/Parser/Lrc/Utils/TimeTagUtilsTest.cs
@@ -1,0 +1,94 @@
+// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using LrcParser.Parser.Lrc.Utils;
+using NUnit.Framework;
+using static LrcParser.Parser.Lrc.Utils.TimeTagMode;
+
+namespace LrcParser.Tests.Parser.Lrc.Utils;
+
+public class TimeTagUtilsTest
+{
+    #region Decode
+
+    // LINE TIME TAG TESTS
+    [TestCase("[00:00.00]", LineTimeTag, 0)]
+    [TestCase("[00:06.00]", LineTimeTag, 6000)]
+    [TestCase("[01:00.00]", LineTimeTag, 60000)]
+    [TestCase("[10:00.00]", LineTimeTag, 600000)]
+    [TestCase("[100:00.00]", LineTimeTag, 6000000)]
+    [TestCase("[12:34.567]", LineTimeTag, 754567)]
+    [TestCase("[0:00.00]", LineTimeTag, 0)]
+    [TestCase("[1:00.00][1:02.00]", LineTimeTag, 60000)] // return the first tag's value if multiple tags are provided.
+    // WORD TIME TAG TESTS
+    [TestCase("<00:00.00>", WordTimeTag, 0)]
+    [TestCase("<00:06.00>", WordTimeTag, 6000)]
+    [TestCase("<01:00.00>", WordTimeTag, 60000)]
+    [TestCase("<10:00.00>", WordTimeTag, 600000)]
+    [TestCase("<100:00.00>", WordTimeTag, 6000000)]
+    [TestCase("<12:34.567>", WordTimeTag, 754567)]
+    [TestCase("<0:00.00>", WordTimeTag, 0)] // prevent throw error in some invalid format.
+    [TestCase("<1:00.00><1:02.00>", WordTimeTag, 60000)] // return the first tag's value if multiple tags are provided.
+    public void TestConvertTimeTagToMilliseconds(string timeTag, TimeTagMode mode, int expectedMilliseconds)
+    {
+        var actual = TimeTagUtils.ConvertTimeTagToMilliseconds(timeTag, mode);
+
+        Assert.That(actual, Is.EqualTo(expectedMilliseconds));
+    }
+
+    // LINE TIME TAG TESTS
+    [TestCase("[--:--.--]", LineTimeTag)]
+    [TestCase("[]", LineTimeTag)]
+    [TestCase("<1:00.00>", LineTimeTag)] // fail when parsing a word time tag as line time tag
+    // WORD TIME TAG TESTS
+    [TestCase("<--:--.-->", WordTimeTag)]
+    [TestCase("<>", WordTimeTag)]
+    [TestCase("[1:00.00]", WordTimeTag)] // fail when parsing a line time tag as word time tag
+    public void TestConvertTimeTagToMillisecondsWithInvalidValue(string timeTag, TimeTagMode mode)
+    {
+        Assert.Throws<InvalidOperationException>(() => TimeTagUtils.ConvertTimeTagToMilliseconds(timeTag, mode));
+    }
+
+    #endregion
+
+    #region Encode
+
+    [TestCase(0, "[00:00.00]")]
+    [TestCase(6000, "[00:06.00]")]
+    [TestCase(60000, "[01:00.00]")]
+    [TestCase(600000, "[10:00.00]")]
+    [TestCase(6000000, "[100:00.00]")]
+    public void TestConvertMillisecondsToLineTimeTag(int milliseconds, string expectedTimeTag)
+    {
+        var actual = TimeTagUtils.ConvertMillisecondsToTimeTag(milliseconds, LineTimeTag);
+
+        Assert.That(actual, Is.EqualTo(expectedTimeTag));
+    }
+
+    [TestCase(-1)]
+    public void TestConvertMillisecondsToLineTimeTagWithInvalidValue(int milliseconds)
+    {
+        Assert.Throws<InvalidOperationException>(() => TimeTagUtils.ConvertMillisecondsToTimeTag(milliseconds, LineTimeTag));
+    }
+
+    [TestCase(0, "<00:00.00>")]
+    [TestCase(6000, "<00:06.00>")]
+    [TestCase(60000, "<01:00.00>")]
+    [TestCase(600000, "<10:00.00>")]
+    [TestCase(6000000, "<100:00.00>")]
+    public void TestConvertMillisecondsToWordTimeTag(int milliseconds, string expectedTimeTag)
+    {
+        var actual = TimeTagUtils.ConvertMillisecondsToTimeTag(milliseconds, WordTimeTag);
+
+        Assert.That(actual, Is.EqualTo(expectedTimeTag));
+    }
+
+    [TestCase(-1)]
+    public void TestConvertMillisecondsToWordTimeTagWithInvalidValue(int milliseconds)
+    {
+        Assert.Throws<InvalidOperationException>(() => TimeTagUtils.ConvertMillisecondsToTimeTag(milliseconds, WordTimeTag));
+    }
+
+    #endregion
+}

--- a/LrcParser/Parser/Lrc/Utils/LrcStartTimeUtils.cs
+++ b/LrcParser/Parser/Lrc/Utils/LrcStartTimeUtils.cs
@@ -2,54 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Text.RegularExpressions;
+using static LrcParser.Parser.Lrc.Utils.TimeTagMode;
 
 namespace LrcParser.Parser.Lrc.Utils;
 
-public class LrcStartTimeUtils
+public static class LrcStartTimeUtils
 {
-    // technically should be @"\[(\d{2,}):(\d{2})\.(\d{2})\]", but might be small case that start time format is invalid.
-    private static readonly Regex start_time_regex = new(@"\[(\d{1,}):(\d{1,})\.(\d{1,})\]");
-
     /// <summary>
-    /// Separate the lyric format from [100:00.00][100:02.00] When the truth is found to be lies.
-    /// to:
-    /// [100:00.00][100:02.00]
-    /// When the truth is found to be lies
+    /// Split an LRC lyrics line into parsed line time tags and the lyric text.
     /// </summary>
-    /// <param name="line"></param>
-    /// <returns></returns>
+    /// <param name="line">The lyrics line in the LRC format.</param>
+    /// <returns>
+    /// A tuple of the form <c>(startTimes, text)</c> where <c>startTimes</c> is an array of start times in milliseconds,
+    /// and <c>text</c> is the lyric text without time tags.
+    /// </returns>
     internal static Tuple<int[], string> SplitLyricAndTimeTag(string line)
     {
         if (string.IsNullOrWhiteSpace(line))
             return new Tuple<int[], string>([], string.Empty);
 
         // get all matched startTime
-        MatchCollection matches = start_time_regex.Matches(line);
+        MatchCollection matches = TimeTagUtils.LINE_TIME_TAG_REGEX.Matches(line);
 
-        var startTimes = matches.Select(x => ConvertTimeTagToMillionSecond(x.Value)).ToArray();
-        var lyric = start_time_regex.Replace(line, "").Trim();
+        var startTimes = matches.Select(x => TimeTagUtils.ConvertTimeTagToMilliseconds(x.Value, LineTimeTag)).ToArray();
+        var lyric = TimeTagUtils.LINE_TIME_TAG_REGEX.Replace(line, "").Trim();
 
         return new Tuple<int[], string>(startTimes, lyric);
-    }
-
-    /// <summary>
-    /// Convert the [1:00.00] to 60000
-    /// </summary>
-    /// <param name="timeTag"></param>
-    /// <returns></returns>
-    internal static int ConvertTimeTagToMillionSecond(string timeTag)
-    {
-        Match match = start_time_regex.Match(timeTag);
-
-        if (!match.Success)
-            throw new InvalidOperationException("Time tag format is invalid.");
-
-        int minutes = int.Parse(match.Groups[1].Value);
-        int seconds = int.Parse(match.Groups[2].Value);
-        int hundredths = int.Parse(match.Groups[3].Value);
-        hundredths = (hundredths < 100) ? hundredths : (hundredths / 10);
-
-        return minutes * 60 * 1000 + seconds * 1000 + hundredths * 10;
     }
 
     /// <summary>
@@ -60,39 +38,23 @@ public class LrcStartTimeUtils
     /// [01:00.00][01:06.00] When the truth is found to be lies
     /// </summary>
     /// <param name="startTimes"></param>
-    /// <param name="lyric"></param>
+    /// <param name="text"></param>
     /// <returns></returns>
-    internal static string JoinLyricAndTimeTag(int[] startTimes, string lyric)
+    internal static string JoinLyricAndTimeTag(int[] startTimes, string text)
     {
         if (startTimes.Any() == false)
-            throw new InvalidOperationException("Should contains at least one start time.");
+            throw new InvalidOperationException("Missing one or more start times.");
 
-        if (start_time_regex.Matches(lyric).Any())
-            throw new InvalidOperationException("lyric should not contains any start time-tag info.");
+        if (TimeTagUtils.LINE_TIME_TAG_REGEX.Matches(text).Any())
+            throw new InvalidOperationException("lyric should not contain any line time tags.");
 
         if (startTimes.Length == 0)
-            return lyric;
+            return text;
 
-        var result = startTimes.Aggregate(string.Empty, (current, t) => current + ConvertMillionSecondToTimeTag(t));
+        var result = startTimes.Aggregate(string.Empty, (current, t) =>
+            current + TimeTagUtils.ConvertMillisecondsToTimeTag(t, LineTimeTag)
+        );
 
-        return result + " " + lyric.Trim();
-    }
-
-    /// <summary>
-    /// Convert the 60000 to [1:00.00]
-    /// </summary>
-    /// <param name="milliseconds"></param>
-    /// <returns></returns>
-    internal static string ConvertMillionSecondToTimeTag(int milliseconds)
-    {
-        if (milliseconds < 0)
-            throw new InvalidOperationException($"{nameof(milliseconds)} should be greater than 0.");
-
-        int totalSeconds = milliseconds / 1000;
-        int minutes = totalSeconds / 60;
-        int seconds = totalSeconds % 60;
-        int hundredths = (milliseconds % 1000) / 10;
-
-        return $"[{minutes:D2}:{seconds:D2}.{hundredths:D2}]";
+        return result + " " + text.Trim();
     }
 }

--- a/LrcParser/Parser/Lrc/Utils/LrcTimedTextUtils.cs
+++ b/LrcParser/Parser/Lrc/Utils/LrcTimedTextUtils.cs
@@ -1,17 +1,14 @@
 // Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Text.RegularExpressions;
 using LrcParser.Model;
 using LrcParser.Utils;
+using static LrcParser.Parser.Lrc.Utils.TimeTagMode;
 
 namespace LrcParser.Parser.Lrc.Utils;
 
 internal static class LrcTimedTextUtils
 {
-    // technically should be @"\<(\d{2,}):(\d{2})\.(\d{2})\>", but might be small case that start time format is invalid.
-    private static readonly Regex start_time_regex = new(@"\<(\d{1,}):(\d{1,})\.(\d{1,})\>");
-
     /// <summary>
     ///
     /// </summary>
@@ -22,7 +19,7 @@ internal static class LrcTimedTextUtils
         if (string.IsNullOrEmpty(timedText))
             return new Tuple<string, SortedDictionary<TextIndex, int>>("", new SortedDictionary<TextIndex, int>());
 
-        var matchTimeTags = start_time_regex.Matches(timedText);
+        var matchTimeTags = TimeTagUtils.WORD_TIME_TAG_REGEX.Matches(timedText);
 
         var endTextIndex = timedText.Length;
 
@@ -50,7 +47,7 @@ internal static class LrcTimedTextUtils
 
             var state = hasText && !isEmptyStringNext ? IndexState.Start : IndexState.End;
             var textIndex = text.Length - (state == IndexState.Start ? 0 : 1);
-            var time = ConvertTimeTagToMillionSecond(match.Value);
+            var time = TimeTagUtils.ConvertTimeTagToMilliseconds(match.Value, WordTimeTag);
 
             // using try add because it might be possible with duplicated time-tag position in the lyric.
             timeTags.TryAdd(new TextIndex(textIndex, state), time);
@@ -62,26 +59,6 @@ internal static class LrcTimedTextUtils
         return new Tuple<string, SortedDictionary<TextIndex, int>>(text, timeTags);
     }
 
-    /// <summary>
-    /// Convert the &lt;1:00.00&gt; to 60000
-    /// </summary>
-    /// <param name="timeTag"></param>
-    /// <returns></returns>
-    internal static int ConvertTimeTagToMillionSecond(string timeTag)
-    {
-        Match match = start_time_regex.Match(timeTag);
-
-        if (!match.Success)
-            throw new InvalidOperationException("Time tag format is invalid.");
-
-        int minutes = int.Parse(match.Groups[1].Value);
-        int seconds = int.Parse(match.Groups[2].Value);
-        int hundredths = int.Parse(match.Groups[3].Value);
-        hundredths = (hundredths < 100) ? hundredths : (hundredths / 10);
-
-        return minutes * 60 * 1000 + seconds * 1000 + hundredths * 10;
-    }
-
     internal static string ToTimedText(string text, SortedDictionary<TextIndex, int> timeTags)
     {
         var insertIndex = 0;
@@ -90,7 +67,7 @@ internal static class LrcTimedTextUtils
 
         foreach (var (textIndex, time) in timeTags)
         {
-            var timeTagString = ConvertMillionSecondToTimeTag(time);
+            var timeTagString = TimeTagUtils.ConvertMillisecondsToTimeTag(time, WordTimeTag);
             var stringIndex = TextIndexUtils.ToGapIndex(textIndex);
             timedText = timedText.Insert(insertIndex + stringIndex, timeTagString);
 
@@ -98,23 +75,5 @@ internal static class LrcTimedTextUtils
         }
 
         return timedText;
-    }
-
-    /// <summary>
-    /// Convert the 60000 to &lt;1:00.00&gt;
-    /// </summary>
-    /// <param name="milliseconds"></param>
-    /// <returns></returns>
-    internal static string ConvertMillionSecondToTimeTag(int milliseconds)
-    {
-        if (milliseconds < 0)
-            throw new InvalidOperationException($"{nameof(milliseconds)} should be greater than 0.");
-
-        int totalSeconds = milliseconds / 1000;
-        int minutes = totalSeconds / 60;
-        int seconds = totalSeconds % 60;
-        int hundredths = (milliseconds % 1000) / 10;
-
-        return $"<{minutes:D2}:{seconds:D2}.{hundredths:D2}>";
     }
 }

--- a/LrcParser/Parser/Lrc/Utils/TimeTagUtils.cs
+++ b/LrcParser/Parser/Lrc/Utils/TimeTagUtils.cs
@@ -1,0 +1,84 @@
+using System.Text.RegularExpressions;
+
+namespace LrcParser.Parser.Lrc.Utils;
+
+internal static class TimeTagUtils
+{
+    internal static readonly Regex LINE_TIME_TAG_REGEX = new(@"\[(\d{1,}):(\d{2})\.(\d{2,3})\]");
+    internal static readonly Regex WORD_TIME_TAG_REGEX = new(@"\<(\d{1,}):(\d{2})\.(\d{2,3})\>");
+
+    /// <summary>
+    /// Convert the given time tag to milliseconds.
+    /// Both line time tag and word time tag are supported, as given by the mode.
+    /// </summary>
+    /// <param name="timeTag">
+    /// A time tag string of the form [01:00.00] or &lt;01:00.00&gt;.
+    /// Time tags using milliseconds are also supported.
+    /// </param>
+    /// <param name="mode">The mode of the time tag, which should match the passed time tag string.</param>
+    /// <returns></returns>
+    internal static int ConvertTimeTagToMilliseconds(string timeTag, TimeTagMode mode)
+    {
+        Regex regex = mode switch
+        {
+            TimeTagMode.LineTimeTag => LINE_TIME_TAG_REGEX,
+            TimeTagMode.WordTimeTag => WORD_TIME_TAG_REGEX,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        Match match = regex.Match(timeTag);
+
+        if (!match.Success)
+        {
+            throw new InvalidOperationException($"Invalid time tag format. Expected [01:00.00] or <01:00.00> but got {timeTag}.");
+        }
+
+        int minutes = int.Parse(match.Groups[1].Value);
+        int seconds = int.Parse(match.Groups[2].Value);
+        string decimalString = match.Groups[3].Value;
+        int decimalPart = int.Parse(decimalString);
+        int millis = decimalString.Length > 2 ? decimalPart : decimalPart * 10;
+
+        return (minutes * 60 + seconds) * 1000 + millis;
+    }
+
+    /// <summary>
+    /// Converts a time value in milliseconds to a time tag string.
+    /// The returned string uses the format corresponding to the given mode:
+    /// [mm:ss.xx] for line time tags and &lt;mm:ss.xx&gt; for word time tags.
+    /// </summary>
+    /// <param name="milliseconds">The time value in milliseconds. Must be non-negative.</param>
+    /// <param name="mode">The mode to determine the tag format.</param>
+    /// <returns>
+    /// A time tag string formatted according to the specified mode.
+    /// </returns>
+    internal static string ConvertMillisecondsToTimeTag(int milliseconds, TimeTagMode mode)
+    {
+        if (milliseconds < 0)
+        {
+            throw new InvalidOperationException($"{nameof(milliseconds)} should be greater than 0.");
+        }
+
+        int totalSeconds = milliseconds / 1000;
+        int minutes = totalSeconds / 60;
+        int seconds = totalSeconds % 60;
+        int hundredths = milliseconds % 1000 / 10;
+
+        return mode switch
+        {
+            TimeTagMode.LineTimeTag => $"[{minutes:D2}:{seconds:D2}.{hundredths:D2}]",
+            TimeTagMode.WordTimeTag => $"<{minutes:D2}:{seconds:D2}.{hundredths:D2}>",
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+    }
+}
+
+/// <summary>
+/// The time tag mode used for <see cref="TimeTagUtils"/>.
+/// Must be public for tests.
+/// </summary>
+public enum TimeTagMode
+{
+    LineTimeTag,
+    WordTimeTag,
+}


### PR DESCRIPTION
Time tags are now required to specify exactly two second digits, and at least two and at most three centisecond/millisecond digits.

Implementations for both time tag parsers are merged to reduce code duplication.